### PR TITLE
fix(ci): pin npm to 11.15.0 so `npm stage publish` works

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,5 +36,8 @@ jobs:
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+      # npm stage publish requires npm >= 11.15.0, newer than the npm bundled with Node 24.
+      # Remove this step once setup-node's default Node ships npm >= 11.15.0.
+      - run: npm install -g npm@11.15.0
       - run: npm ci
       - run: npm stage publish --provenance


### PR DESCRIPTION
## Problem
The `publish` job runs `npm stage publish` (staged publishing, shipped 2026-05-22), which requires npm 11.15.0 or newer. `actions/setup-node` installs the npm bundled with the runner's Node, and Node 24 ships npm 11.13.0, so the publish job fails at the `npm stage publish` step on the next release.

## Fix
Upgrade npm before the staged-publish step in the `publish` job:

```yaml
- run: npm install -g npm@11.15.0
```

`registry.npmjs.org:443` is already in the `harden-runner` egress allowlist, so the new install step needs no egress changes. The step can be removed once setup-node's default Node bundles npm 11.15.0 or newer.